### PR TITLE
Add preview cutoff markers to project pages

### DIFF
--- a/_posts/portfolio/projects/2014-01-01-matelight.md
+++ b/_posts/portfolio/projects/2014-01-01-matelight.md
@@ -24,6 +24,7 @@ tags:
 <h3>Overview</h3>
 
 Matelight is an piece that displays various patterns and that can be modularly set up in different sizes. More info <a href="/tech/2015/03/08/matepi-raspberry-pi-meets-mate-crates-how-to.html">here</a>. It was displayed in different clubs and parties.
+<!--more-->
 <p>
 <ul>
   <li>480 bottle of Club Mate in 24 crates</li>
@@ -32,7 +33,7 @@ Matelight is an piece that displays various patterns and that can be modularly s
   <li>raspberry pi microcontroller</li>
   <li>power supply</li>
 </ul>
-</p><!--more-->
+</p>
 </section>
 <section>
 <h3>Gallery</h3>

--- a/_posts/portfolio/projects/2019-01-01-forrest-microgravity.md
+++ b/_posts/portfolio/projects/2019-01-01-forrest-microgravity.md
@@ -22,6 +22,7 @@ tags:
 <section>
 <h3>Overview</h3>
 By night this light installation creates the illusion of 5 light bars floating mid air. The bright lights project intertwined light beams onto the ground with changing modes between stroboscopic and calm patterns. Due to the suspension the tree movements are picked up by the light arrangement. Displayed at <a href="https://garbiczfestival.com">Garbiczfestival 2019</a>.
+<!--more-->
 <p>
 <ul>
   <li>aluminium bars</li>
@@ -29,7 +30,7 @@ By night this light installation creates the illusion of 5 light bars floating m
   <li>steel wire</li>
   <li>Madmapper software</li>
 </ul>
-</p><!--more-->
+</p>
 </section>
 <section>
 <h3>Gallery</h3>

--- a/_posts/portfolio/projects/2020-10-01-speculative-ai.md
+++ b/_posts/portfolio/projects/2020-10-01-speculative-ai.md
@@ -23,6 +23,7 @@ tags:
 The SpeculativeAI series consists of aesthetic experiments aimed at making the processes of artificial neural networks perceptible to visitors through audiovisual translation.
 
 The latest work questions an AI’s capacity for empathy and purpose while communicating with another AI. Conceptually supported by the Center for Artificial Intelligence (University of Oviedo), two independent AI systems were set up to communicate using an invented language of audiovisual associations.
+<!--more-->
 <p>
 <ul>
 <li>The light object is a spherical structure with an 80cm diameter, composed of a chaotic heap of 120m LED stripe, a microphone, and an embedded AI computing device (Jetson Nano). It hears sounds and creates images.</li>

--- a/_posts/portfolio/projects/2021-10-01-clock.md
+++ b/_posts/portfolio/projects/2021-10-01-clock.md
@@ -25,6 +25,8 @@ tags:
 
 The stone is moved continuously, requiring 12 hours to travel from the ceiling at noon to just above the floor at midnight.  Illustrating time, with time. I was fully responsible for the programming (C++) and ensuring the correct timing of the clock mechanism as well as developing the electronic hardware. Calibrating the stone was particularly tricky because the motor had a drift which needed to be measured and accounted for precisely. The artist is <a href="https://www.benjaminlangholz.com/#/clock/">Benjamin Langholz</a>.
 
+<!--more-->
+
 </section>
 
 <section>

--- a/_posts/portfolio/projects/2022-06-01-hingecore.md
+++ b/_posts/portfolio/projects/2022-06-01-hingecore.md
@@ -24,6 +24,7 @@ tags:
 HingeCore introduces a novel laser-cutting approach utilizing foamcore to create 3D structures with finger hinges for fast and glue-free assembly. This method supports the creation of robust, aesthetic, and functional models, ranging from furniture to art objects.
 
 HingeCoreMaker is the accompanying software tool, seamlessly integrating with 3D modeling platforms to automate the conversion of 3D designs into 2D laser-cutting layouts, optimizing for precision and efficiency.
+<!--more-->
 
 <p>
 <ul>

--- a/_posts/portfolio/projects/2022-09-01-systemfailed.md
+++ b/_posts/portfolio/projects/2022-09-01-systemfailed.md
@@ -21,6 +21,7 @@ tags:
 <section>
 <h3>Overview</h3>
 System Failed is an AI-powered interactive installation that combines advanced motion tracking, machine learning, and real-time audience interaction. I developed the entire software pipeline, from processing raw laser tracking data to generating live path predictions. Key features include the ability to record and retrain models using new data and a PyQT5-based graphical user interface for system control. The production was succesfully shown to a live audience 11 times.
+<!--more-->
 <p>
 </p>
 <p>

--- a/_posts/portfolio/projects/2025-11-01-doyle-packing.md
+++ b/_posts/portfolio/projects/2025-11-01-doyle-packing.md
@@ -26,6 +26,7 @@ The software can be used to explore evolving geometric textures, then translate 
 etching and laser engraving with a fibo laser. The current pipeline renders animated patterns, prepares high-resolution frames for
 laser engraving. The surfaces reflections can be changed based on the angle of the engrave line pattern.
 </p>
+<!--more-->
 <p>
 <a href="https://github.com/kryptokommunist/doyle_packing" target="_blank">GitHub Repository</a>
 </p>

--- a/_posts/portfolio/projects/2025-12-01-heater-spiral.md
+++ b/_posts/portfolio/projects/2025-12-01-heater-spiral.md
@@ -21,6 +21,7 @@ tags:
 <section>
 <h3>Overview</h3>
 Heater Spiral is a wearable body-computer interface that delivers gentle, programmable warmth through a spiral heater trace. I designed and assembled the circular PCB from scratch, integrating a MOSFET-controlled heater that can raise the surface temperature to around 50&nbsp;°C. One application I explored was wearing it as a necklace over the heart with rhythmic warm-up and cooldown phases to anchor attention in the body—similar to metta meditation sessions I tested during retreat. I also prototyped an app that modulates heat based on how near another wearer is, and I plan to redesign the next iteration with a UWB chip for more accurate distance sensing.
+<!--more-->
 <p></p>
 <p>
 <a href="https://github.com/kryptokommunist/heater_spiral" target="_blank">GitHub Repository</a> |


### PR DESCRIPTION
## Summary
- add `<!--more-->` markers after the first image and overview paragraph for all portfolio project markdowns to standardize paginator previews

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e01084030832189a520a554de0319)