### PR TITLE
Honor project excerpts and more tags

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -23,8 +23,12 @@ pagination:
         {% endif %}</p>
     </header>
 
+    {% assign post_preview = post.excerpt %}
+    {% if post.content contains '<!--more-->' %}
+      {% assign post_preview = post.content | split: '<!--more-->' | first %}
+    {% endif %}
     <div class="post-content" itemprop="articleBody">
-      {{ post.excerpt }}<a href="{{ post.url | relative_url }}">...read more</a>
+      {{ post_preview }}<a href="{{ post.url | relative_url }}">...read more</a>
     </div>
     <div class="post-meta post-tags">
       {% for tag in post.tags %}

--- a/portfolio.md
+++ b/portfolio.md
@@ -34,6 +34,10 @@ include: true
 
         <div id="event2Container">
             {% for post in site.categories['portfolio/projects'] %}
+            {% assign post_preview = post.excerpt %}
+            {% if post.content contains '<!--more-->' %}
+                {% assign post_preview = post.content | split: '<!--more-->' | first %}
+            {% endif %}
             <section class="projectCard">
                 <a class="titleLink desktopHide" href="{{ post.url }}">
                     <h2>{{ post.title }}</h2>
@@ -47,7 +51,7 @@ include: true
                     </a>
                     <h3>{{ post.subtitle }}</h3>
                     <p>{{ post.year }}</p>
-                    <p>{{ post.excerpt }}</p>
+                    <p>{{ post_preview }}</p>
                 </div>
             </section>
             {% endfor %}


### PR DESCRIPTION
## Summary
- ensure paginated posts use the `<!--more-->` separator when available
- render project previews from content before the `<!--more-->` marker on the portfolio page

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e065bbf9883218f030739a4df5907)